### PR TITLE
Fix for `si seq pack` command

### DIFF
--- a/javascript/simple-counter-js/README.md
+++ b/javascript/simple-counter-js/README.md
@@ -74,7 +74,7 @@ cd samples/simple-counter-js
 npm install
 
 # make a compressed package with Sequence
-si pack . -o simple-counter-js.tar.gz
+si seq pack . -o simple-counter-js.tar.gz
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send simple-counter-js.tar.gz

--- a/typescript/discord-read/README.md
+++ b/typescript/discord-read/README.md
@@ -23,7 +23,7 @@ Create a file called `config.json` and add:
 ```json
 {
     "token": "DISCORD_BOT_TOKEN_GOES_HERE"
-} 
+}
 ```
 
 Add `config.json` to main directory in `discord-read` sample and follow running process below:
@@ -38,7 +38,7 @@ npm install
 npm run build
 
 # make a compressed package with Sequence
-si pack dist
+si seq pack dist
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send dist.tar.gz

--- a/typescript/discord-write/README.md
+++ b/typescript/discord-write/README.md
@@ -18,7 +18,7 @@ npm install
 npm run build
 
 # make a compressed package with Sequence
-si pack dist
+si seq pack dist
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send dist.tar.gz

--- a/typescript/rss/README.md
+++ b/typescript/rss/README.md
@@ -27,7 +27,7 @@ npm install
 npm run build
 
 # make a compressed package with Sequence
-si pack dist
+si seq pack dist
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send dist.tar.gz

--- a/typescript/slack-read/README.md
+++ b/typescript/slack-read/README.md
@@ -22,7 +22,7 @@ npm install
 npm run build
 
 # make a compressed package with Sequence
-si pack dist
+si seq pack dist
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send dist.tar.gz

--- a/typescript/slack-write/README.md
+++ b/typescript/slack-write/README.md
@@ -21,7 +21,7 @@ npm install
 npm run build
 
 # make a compressed package with Sequence
-si pack dist
+si seq pack dist
 
 # send Sequence to transform hub, this will output Sequence ID
 si seq send dist.tar.gz


### PR DESCRIPTION
There were few readmes that had old versions of the `pack` command. This PR updates outdated commands.