### PR TITLE
Sample Sequence that forwards messages from Topic to Telegram

### DIFF
--- a/python/telegram-write/README.md
+++ b/python/telegram-write/README.md
@@ -1,8 +1,8 @@
 # Send to Telegram
 
-This is a piece of cake sample which simply forwards stream input to a telegram channel.
+This is a piece of cake sample which simply forwards stream input to a telegram channel (in form of messages).
 
-It reads messages from user input or **telegram-inbound** Topic.
+It reads messages from **telegram-inbound** Topic.
 
 ___
 ## Prerequisites
@@ -12,6 +12,8 @@ You need to [add a bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot) 
 The easiest way to achieve that is to follow a few steps given by BotFather here: 
 
 https://t.me/botfather
+
+and type `/newbot`.
 
 After you input a username for your bot, you will see a message from BotFather that includes this part:
 
@@ -40,6 +42,14 @@ Now open `config.json` file and paste your **bot token** and **channel id**:
         "channel": "Put-ChannelID-here"
     }
 }
+
+At last, our bot must be added to the desired channel. In the Telegram client:
+
+1. Inside the channel, click the 3-dotted line in the right upper corner.
+2. Click on "Manage channel" -> "Administrators" -> "Add Administrator".
+3. Type in your bot's name and click on it.
+4. Hit 'save'.
+
 ```
 
 ## Running
@@ -60,10 +70,9 @@ npm run build
 si seq deploy dist -f config.json
 
 # Input some data
-si inst input -
+si inst output -
 ```
-
-Now type something in and you should see the same phrase on your telegram channel.
+As soon as anything comes through the Topic, it will be forwarded to the Telegram channel.
 ___
 
 

--- a/python/telegram-write/README.md
+++ b/python/telegram-write/README.md
@@ -1,0 +1,69 @@
+# Send to Telegram
+
+This is a piece of cake sample which simply forwards stream input to a telegram channel.
+
+It reads messages from user input or **telegram-inbound** Topic.
+
+___
+## Prerequisites
+
+You need to [add a bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot) to your Telegram channel which will send messages for you.
+
+The easiest way to achieve that is to follow a few steps given by BotFather here: 
+
+https://t.me/botfather
+
+After you input a username for your bot, you will see a message from BotFather that includes this part:
+
+`"Use this token to access the HTTP API:`
+/token/
+
+`Keep your token secure and store it safely, it can be used by anyone to control your bot."`
+
+**You'll need that token to control the bot.**
+
+Next, you need to find the ID of the channel your bot will send messages to. There are several ways to do this, I'll show the least intrusive one (that doesn't include inviting other bots).
+
+1. Go to https://web.telegram.org
+2. Hover over the desired channel
+3. Look at the URL, it should look like:
+    `https://web.telegram.org/k/#-1636919854`
+4. Take the digit part, add `-100` to the beggining:
+```
+-1001636919854   # That's your channel ID!
+```
+Now open `config.json` file and paste your **bot token** and **channel id**:
+```
+{
+    "credentials": {
+        "token": "Put-Token-here",
+        "channel": "Put-ChannelID-here"
+    }
+}
+```
+
+## Running
+> 💡**NOTE:** Packaging of Python Sequences is not very "pythonic" for now. If you have any idea, how we should resolve it for your comfort, please let us know [here](https://github.com/scramjetorg/transform-hub/issues/598).
+
+> ❗ Remember to [setup transform-hub locally](https://docs.scramjet.org/platform/self-hosted-installation) or use the [platform's environment](https://docs.scramjet.org/platform/quick-start) for the sequence deployment.
+
+Open the terminal and run the following commands:
+
+```bash
+# Make sure you are inside 'telegram-write' directory, otherwise:
+cd python/telegram-write
+
+# Install dependencies
+npm run build
+
+# Deploy sample to STH
+si seq deploy dist -f config.json
+
+# Input some data
+si inst input -
+```
+
+Now type something in and you should see the same phrase on your telegram channel.
+___
+
+

--- a/python/telegram-write/README.md
+++ b/python/telegram-write/README.md
@@ -69,8 +69,6 @@ npm run build
 # Deploy sample to STH
 si seq deploy dist -f config.json
 
-# Input some data
-si inst output -
 ```
 As soon as anything comes through the Topic, it will be forwarded to the Telegram channel.
 ___

--- a/python/telegram-write/config.json
+++ b/python/telegram-write/config.json
@@ -1,0 +1,6 @@
+{
+    "credentials": {
+        "token": "",
+        "channel": ""
+    }
+}

--- a/python/telegram-write/main.py
+++ b/python/telegram-write/main.py
@@ -1,0 +1,19 @@
+from scramjet.streams import Stream
+import requests
+
+provides = {
+   'provides': 'telegram-inbound',
+   'contentType': 'text/plain'
+}
+
+
+def send_message(msg: str):
+	url = f"https://api.telegram.org/bot{run.TOKEN}/sendMessage?chat_id={run.CHANNEL_ID}&text={msg}"
+	requests.get(url).json()
+
+async def run(context, input):
+	config = context.config
+	run.TOKEN = config['credentials']['token']
+	run.CHANNEL_ID = config['credentials']['channel']
+	
+	return input.each(send_message)

--- a/python/telegram-write/main.py
+++ b/python/telegram-write/main.py
@@ -1,8 +1,8 @@
 from scramjet.streams import Stream
 import requests
 
-provides = {
-   'provides': 'telegram-inbound',
+requires = {
+   'requires': 'telegram-inbound',
    'contentType': 'text/plain'
 }
 

--- a/python/telegram-write/package.json
+++ b/python/telegram-write/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@scramjet/telegram-write",
+  "version": "0.1.0",
+  "main": "main.py",
+  "author": "S4Adam",
+  "license": "GPL-3.0",
+  "description": "Forwards input to a specified telegram channel.",
+  "keywords": [
+    "easy",
+    "Telegram",
+    "Business Automation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scramjetorg/platform-samples/tree/main/python/telegram-write"
+  },
+  "engines": {
+    "python3": "3.8.0"
+  },
+  "scripts": {
+    "build": "mkdir -p dist/__pypackages__/ && pip3 install -t dist/__pypackages__/ -r requirements.txt && cp -t ./dist/ *.py *.json",
+    "clean": "rm -rf ./dist"
+  }
+}

--- a/python/telegram-write/requirements.txt
+++ b/python/telegram-write/requirements.txt
@@ -1,0 +1,2 @@
+scramjet-framework-py
+requests


### PR DESCRIPTION
This sample sends input to a Telegram channel via HTTP api.
It listens on `telegram-inbound` Topic.

Some prerequisites are required:
 - setting up a Telegram bot and getting its token
 - getting the desired channel ID
They then should be specified in config.json file.